### PR TITLE
Fix: Incorrect text indexing

### DIFF
--- a/login.js
+++ b/login.js
@@ -133,8 +133,8 @@ function setupPinInputListeners() {
             e.preventDefault();
             const text = e.clipboardData.getData('text/plain');
             if (text != null && text.length > 0 && /^\d+$/.test(text)) {
-                for (let i = index; i < Math.min(text.length, pinInputs.length); i++) {
-                    pinInputs[i].value = text[i];
+                for (let i = index; i < Math.min(index + text.length, pinInputs.length); i++) {
+                    pinInputs[i].value = text[i - index];
                     pinInputs[i].focus();
                 }
                 const pin = pinInputs.map(input => input.value).join('');


### PR DESCRIPTION
Apologies had a bug in #19 where if paste was started from index that's not 0, it will paste the text partially as well instead of pasting from beginning. 
This fixes that behavior, so regardless of where user starts from, it will always begin text from index 0 and onwards.