### PR TITLE
fix: Allow DUMBDO_PIN to be set via docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN mkdir -p data
 
 # Environment variables
 ENV PORT=3000
-ENV DUMBDO_PIN=
+# Don't set a default for DUMBDO_PIN as it will override docker-compose values
+# ENV DUMBDO_PIN=
 
 # Expose port (use the PORT env variable)
 EXPOSE ${PORT}


### PR DESCRIPTION
This commit fixes an issue where the DUMBDO_PIN environment variable wasn't being properly recognized when set in docker-compose.yml. The problem was caused by the explicit ENV DUMBDO_PIN= declaration in the Dockerfile which was overriding any values provided via docker-compose.

Changes:
- Commented out ENV DUMBDO_PIN= line in Dockerfile
- Added explanatory comment to prevent future regression