### PR TITLE
Add arm64 arch and tags to github cd workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,28 +5,41 @@ on:
     branches:
       - main # Trigger the workflow on pushes to the main branch
 
+env:
+  DOCKER_IMAGE: dumbwareio/dumbdo
+  PLATFORMS: linux/amd64,linux/arm64
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-
     steps:
-      # Step 1: Check out the repository
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # Step 2: Log in to Docker Hub
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # Step 3: Build the Docker image
-      - name: Build Docker Image
+      - name: Set Docker tags
+        id: docker_meta
         run: |
-          docker build -t dumbwareio/dumbdo:latest .
+          TAGS="${{ env.DOCKER_IMAGE }}:${{ github.sha }}"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            TAGS+=" ${{ env.DOCKER_IMAGE }}:latest"
+          elif [ "${{ github.ref }}" = "refs/heads/testing" ]; then
+            TAGS+=" ${{ env.DOCKER_IMAGE }}:testing"
+          fi
+          echo "DOCKER_TAGS=$TAGS" >> $GITHUB_ENV
 
-      # Step 4: Push the Docker image to Docker Hub
-      - name: Push Docker Image
+      - name: Build and Push Multi-Platform Image
         run: |
-          docker push dumbwareio/dumbdo:latest 
+          docker buildx create --use
+          docker buildx build --platform ${{ env.PLATFORMS }} \
+            --tag ${{ env.DOCKER_IMAGE }}:${{ github.sha }} \
+            --tag ${{ env.DOCKER_IMAGE }}:latest \
+            --push .


### PR DESCRIPTION
@abiteman update here to include arm64 arch to docker image. i've tested this cd script on my own repos and it works for me but wont be able to test this for dumbwareio's dockerhub

FIx: https://github.com/DumbWareio/DumbDo/issues/23

Changes:
- include `linux/arm64`
- added tags for latest and sha tag
- use buildx to build for each platform then push

let me know if you wanted to update this to something else 🙏🏻