### PR TITLE
Add a SingleListMode for Simplicity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,5 @@ DUMBDO_SITE_TITLE=DumbDo
 # (Optional) Restrict origins - ex: https://subdomain.domain.tld,https://auth.proxy.tld,http://internalip:port' (default is '*')
 # - ALLOWED_ORIGINS=http://localhost:3000
 # NODE_ENV=development # default production (development allows all origins)
+
+SINGLE_LIST=false

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A stupidly simple todo list application that just works. No complex database, no
 |----------|-------------|---------|----------|
 | PORT | The port number the server will listen on | 3000 | No |
 | DUMBDO_PIN | PIN protection for accessing todos (4-10 digits) | - | No |
+| SINGLE_LIST | Show a single List of ToDos (without the selector) | false | No |
 
 ## Quick Start
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       # (Optional) Restrict origins - ex: https://subdomain.domain.tld,https://auth.proxy.tld,http://internalip:port' (default is '*')
       # - ALLOWED_ORIGINS=http://localhost:3000
       # - NODE_ENV=development # default production (development allows all origins)
-      - SINGLE_LIST=${SINGLE_LIST:-false} # default false (true = single list mode, false = multi list mode)
+      - SINGLE_LIST=${SINGLE_LIST:-false}
     #healthcheck:
     #  test: wget --spider -q  http://127.0.0.1:3000
     #  start_period: 20s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       # (Optional) Restrict origins - ex: https://subdomain.domain.tld,https://auth.proxy.tld,http://internalip:port' (default is '*')
       # - ALLOWED_ORIGINS=http://localhost:3000
       # - NODE_ENV=development # default production (development allows all origins)
+      - SINGLE_LIST=${SINGLE_LIST:-false} # default false (true = single list mode, false = multi list mode)
     #healthcheck:
     #  test: wget --spider -q  http://127.0.0.1:3000
     #  start_period: 20s

--- a/public/app.js
+++ b/public/app.js
@@ -20,9 +20,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const deleteListBtn = document.getElementById('deleteList');
     const addListBtn = document.getElementById('addList');
 
+    const listControls = document.getElementById('listControls');
 
     // Set up list selector event handlers once
     const selectorContainer = listSelector.parentElement;
+
+    function handleSingleListMode() {
+        const isSingleList = document.body.getAttribute('data-single-list') === 'true';
+        if (listControls) listControls.style.display = isSingleList ? 'none' : '';
+    }
 
     // Show/hide custom select on click
     function handleSelectorClick(e) {
@@ -158,6 +164,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
         selectorContainer.appendChild(customSelect);
+        handleSingleListMode();
     }
 
     function switchList(listId) {
@@ -542,8 +549,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 document.getElementById('page-title').textContent = `${config.siteTitle} - Stupidly Simple Todo List`;
                 document.getElementById('header-title').textContent = config.siteTitle;
-                
-                loadTodos();       
+                document.body.setAttribute('data-single-list', config.singleList);
+
+                loadTodos();
             })
             .catch(err => {
                 console.error('Error loading site config:', err);

--- a/public/app.js
+++ b/public/app.js
@@ -1,4 +1,4 @@
-import { ToastManager } from './managers/toast.js'
+import { ToastManager } from './managers/toast.js';
 
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -24,11 +24,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Set up list selector event handlers once
     const selectorContainer = listSelector.parentElement;
-
-    function handleSingleListMode() {
-        const isSingleList = document.body.getAttribute('data-single-list') === 'true';
-        if (listControls) listControls.style.display = isSingleList ? 'none' : '';
-    }
 
     // Show/hide custom select on click
     function handleSelectorClick(e) {
@@ -164,7 +159,6 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
         selectorContainer.appendChild(customSelect);
-        handleSingleListMode();
     }
 
     function switchList(listId) {
@@ -549,7 +543,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 document.getElementById('page-title').textContent = `${config.siteTitle} - Stupidly Simple Todo List`;
                 document.getElementById('header-title').textContent = config.siteTitle;
-                document.body.setAttribute('data-single-list', config.singleList);
+                if (listControls) listControls.style.display = config.singleList ? 'none' : '';
 
                 loadTodos();
             })

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     <div class="app">
         <header>
             <h1 id="header-title">DumbDo</h1>
-            <div class="list-controls">
+            <div class="list-controls" id="listControls" style="display: none;">
                 <div class="list-selector-container">
                     <select id="listSelector" aria-label="Select todo list">
                         <option value="List 1">List 1</option>

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ const { generatePWAManifest } = require('./scripts/pwa-manifest-generator');
 const PORT = process.env.PORT || 3000;
 const PIN = process.env.DUMBDO_PIN;
 const SITE_TITLE = process.env.DUMBDO_SITE_TITLE || 'DumbDo';
+const SINGLE_LIST = process.env.SINGLE_LIST === 'true' || false;
 const MIN_PIN_LENGTH = 4;
 const MAX_PIN_LENGTH = 10;
 const PUBLIC_DIR = path.join(__dirname, 'public');
@@ -167,7 +168,8 @@ app.post('/api/verify-pin', (req, res) => {
 // Get site configuration
 app.get('/api/config', (req, res) => {
     res.json({
-        siteTitle: SITE_TITLE
+        siteTitle: SITE_TITLE,
+        singleList: SINGLE_LIST
     });
 });
 


### PR DESCRIPTION
For super simple use I have added a 'SINGLE_LIST' Mode.

When this is set then only 1 List is used (the first list defined) and the selector is not shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Single-List mode toggled by the SINGLE_LIST environment variable.
  - UI hides the list selector/controls when Single-List mode is enabled.
  - App initializes UI state from server config; server config now exposes singleList.

- Documentation
  - README updated with SINGLE_LIST details (description, default false, optional).

- Chores
  - SINGLE_LIST added to example env and docker configuration with default false.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->