### PR TITLE
Override Full Page Title

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -533,7 +533,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     const initialize = async () => {
-        // Initialize
         fetch(`api/config`)
             .then(resp => resp.json())
             .then(config => {
@@ -541,7 +540,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     throw new Error(config.error);
                 }
 
-                document.getElementById('page-title').textContent = `${config.siteTitle} - Stupidly Simple Todo List`;
+                document.getElementById('page-title').textContent = config.siteTitle;
                 document.getElementById('header-title').textContent = config.siteTitle;
                 if (listControls) listControls.style.display = config.singleList ? 'none' : '';
 


### PR DESCRIPTION
IMO this is expected behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated page title display to show only the site title, removing redundant suffix from browser tab title.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR modifies the page title logic to use only the configured `siteTitle` instead of appending it to "Stupidly Simple Todo List". This allows for full customization of the page title through the configuration, which the author considers expected behavior. Additionally, a comment and trailing newline formatting were cleaned up.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `public/app.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->