### PR TITLE
Internal Container Healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN mkdir -p data
 EXPOSE 3000
 
 # Healthcheck
+RUN apk add --no-cache wget
 HEALTHCHECK --interval=20s --timeout=5s --start-period=20s --retries=3 \
     CMD wget --spider -q http://127.0.0.1:3000 || exit 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,9 @@ RUN mkdir -p data
 # Expose port (internal port)
 EXPOSE 3000
 
+# Healthcheck
+HEALTHCHECK --interval=20s --timeout=5s --start-period=20s --retries=3 \
+    CMD wget --spider -q http://127.0.0.1:3000 || exit 1
+
 # Start the application
 CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,3 @@ services:
       # - ALLOWED_ORIGINS=http://localhost:3000
       # - NODE_ENV=development # default production (development allows all origins)
       - SINGLE_LIST=${SINGLE_LIST:-false}
-    #healthcheck:
-    #  test: wget --spider -q  http://127.0.0.1:3000
-    #  start_period: 20s
-    #  interval: 20s
-    #  timeout: 5s
-    #  retries: 3


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR moves the healthcheck configuration from the Docker Compose file into the Dockerfile itself. The healthcheck uses `wget` to ping the application on port 3000 every 20 seconds with a 5-second timeout, 3 retries, and a 20-second start period. This makes the healthcheck an intrinsic part of the container image rather than being defined at the orchestration layer.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Dockerfile` |
| 2 | `docker-compose.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automatic container health monitoring with periodic validation checks
  * Updated Docker Compose configuration to align with container health monitoring settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->