### PR TITLE
Theme Selector Mobile Layout

### DIFF
--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -73,9 +73,9 @@ button:hover {
 }
 
 #themeToggle {
-    position: absolute;
-    top: 0;
-    right: 0;
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
     background: transparent;
     font-size: 1.5rem;
     padding: 0.5rem;
@@ -86,6 +86,7 @@ button:hover {
     justify-content: center;
     border: 2px solid var(--text);
     border-radius: 50%;
+    z-index: 1000;
 }
 
 #themeToggle:hover {
@@ -634,11 +635,6 @@ input:focus {
     header {
         flex-direction: column;
         gap: 1rem;
-    }
-    
-    #themeToggle {
-        position: static;
-        margin-left: auto;
     }
 }
 

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -86,7 +86,7 @@ button:hover {
     justify-content: center;
     border: 2px solid var(--text);
     border-radius: 50%;
-    z-index: 1000;
+    z-index: 500;
 }
 
 #themeToggle:hover {

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,22 @@
 <body>
     <div class="app">
         <header>
+            <button id="themeToggle" aria-label="Toggle theme">
+                <svg class="moon" viewBox="0 0 24 24">
+                    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+                </svg>
+                <svg class="sun" viewBox="0 0 24 24">
+                    <circle cx="12" cy="12" r="5"></circle>
+                    <line x1="12" y1="1" x2="12" y2="3"></line>
+                    <line x1="12" y1="21" x2="12" y2="23"></line>
+                    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                    <line x1="1" y1="12" x2="3" y2="12"></line>
+                    <line x1="21" y1="12" x2="23" y2="12"></line>
+                    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                </svg>
+            </button>
             <h1 id="header-title">DumbDo</h1>
             <div class="list-controls" id="listControls" style="display: none;">
                 <div class="list-selector-container">
@@ -40,29 +56,13 @@
                     </button>
                 </div>
             </div>
-            <button id="themeToggle" aria-label="Toggle theme">
-                <svg class="moon" viewBox="0 0 24 24">
-                    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-                </svg>
-                <svg class="sun" viewBox="0 0 24 24">
-                    <circle cx="12" cy="12" r="5"></circle>
-                    <line x1="12" y1="1" x2="12" y2="3"></line>
-                    <line x1="12" y1="21" x2="12" y2="23"></line>
-                    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
-                    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
-                    <line x1="1" y1="12" x2="3" y2="12"></line>
-                    <line x1="21" y1="12" x2="23" y2="12"></line>
-                    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
-                    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
-                </svg>
-            </button>
         </header>
-        
+
         <main>
             <form id="todoForm" class="todo-form">
-                <input 
-                    type="text" 
-                    id="todoInput" 
+                <input
+                    type="text"
+                    id="todoInput"
                     placeholder="What needs to be done?"
                     required
                 >
@@ -86,4 +86,4 @@
 
     <script src="app.js" type="module"></script>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
Enforce Fixed Position for Theme Toggle on Mobile.
This will sit ontop of text if the title is long but I think this is an improvement in 90% of uses to prevent the wasted y space.


## Before

<img width="631" height="390" alt="image" src="https://github.com/user-attachments/assets/438ffc82-b364-4ce4-a00d-c1c2a9ec3257" />

## After

<img width="632" height="311" alt="image" src="https://github.com/user-attachments/assets/4cca5c06-c2ef-4762-9c48-28cd3288eeee" />

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR repositions the theme toggle button to the top of the header element, before the title and list controls, to fix mobile layout issues. The change reduces wasted vertical space on mobile devices by enforcing a fixed position for the theme selector, though it may overlap with long titles in edge cases. The PR also includes minor whitespace cleanup.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `public/index.html` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->